### PR TITLE
Implement `fund-sender` program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,6 +934,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fund-sender"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "solana-program",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/packages/types/fund_sender.ts
+++ b/packages/types/fund_sender.ts
@@ -1,0 +1,377 @@
+export type FundSender = {
+  "version": "0.1.0",
+  "name": "fund_sender",
+  "instructions": [
+    {
+      "name": "registerState",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "outputYieldAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "sunriseState",
+          "type": "publicKey"
+        },
+        {
+          "name": "stateIn",
+          "type": {
+            "defined": "GenericStateInput"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateState",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "stateIn",
+          "type": {
+            "defined": "GenericStateInput"
+          }
+        }
+      ]
+    },
+    {
+      "name": "sendFund",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "outputYieldAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "destinationAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    }
+  ],
+  "accounts": [
+    {
+      "name": "state",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "sunriseState",
+            "type": "publicKey"
+          },
+          {
+            "name": "updateAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "destinationSeed",
+            "type": "bytes"
+          },
+          {
+            "name": "destinationAccount",
+            "type": "publicKey"
+          },
+          {
+            "name": "spendThreshold",
+            "type": "u64"
+          },
+          {
+            "name": "totalSpent",
+            "type": "u64"
+          },
+          {
+            "name": "outputYieldAccountBump",
+            "type": "u8"
+          }
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "GenericStateInput",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "destinationSeed",
+            "type": "bytes"
+          },
+          {
+            "name": "updateAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "destinationAccount",
+            "type": "publicKey"
+          },
+          {
+            "name": "spendThreshold",
+            "type": "u64"
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InsufficientFundsForTransaction",
+      "msg": "Insufficient funds for transaction"
+    },
+    {
+      "code": 6001,
+      "name": "IncorrectOutputYieldAccount",
+      "msg": "Incorrect output yield account"
+    },
+    {
+      "code": 6002,
+      "name": "IncorrectDestinationAccount",
+      "msg": "Incorrect destination account"
+    },
+    {
+      "code": 6003,
+      "name": "Unauthorized",
+      "msg": "Incorrect update authority"
+    }
+  ]
+};
+
+export const IDL: FundSender = {
+  "version": "0.1.0",
+  "name": "fund_sender",
+  "instructions": [
+    {
+      "name": "registerState",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "outputYieldAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "sunriseState",
+          "type": "publicKey"
+        },
+        {
+          "name": "stateIn",
+          "type": {
+            "defined": "GenericStateInput"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateState",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "stateIn",
+          "type": {
+            "defined": "GenericStateInput"
+          }
+        }
+      ]
+    },
+    {
+      "name": "sendFund",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "outputYieldAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "destinationAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    }
+  ],
+  "accounts": [
+    {
+      "name": "state",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "sunriseState",
+            "type": "publicKey"
+          },
+          {
+            "name": "updateAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "destinationSeed",
+            "type": "bytes"
+          },
+          {
+            "name": "destinationAccount",
+            "type": "publicKey"
+          },
+          {
+            "name": "spendThreshold",
+            "type": "u64"
+          },
+          {
+            "name": "totalSpent",
+            "type": "u64"
+          },
+          {
+            "name": "outputYieldAccountBump",
+            "type": "u8"
+          }
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "GenericStateInput",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "destinationSeed",
+            "type": "bytes"
+          },
+          {
+            "name": "updateAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "destinationAccount",
+            "type": "publicKey"
+          },
+          {
+            "name": "spendThreshold",
+            "type": "u64"
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InsufficientFundsForTransaction",
+      "msg": "Insufficient funds for transaction"
+    },
+    {
+      "code": 6001,
+      "name": "IncorrectOutputYieldAccount",
+      "msg": "Incorrect output yield account"
+    },
+    {
+      "code": 6002,
+      "name": "IncorrectDestinationAccount",
+      "msg": "Incorrect destination account"
+    },
+    {
+      "code": 6003,
+      "name": "Unauthorized",
+      "msg": "Incorrect update authority"
+    }
+  ]
+};

--- a/programs/fund-sender/Cargo.toml
+++ b/programs/fund-sender/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "fund-sender"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "fund_sender"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang = "0.28.0"
+solana-program = "1.16.14"

--- a/programs/fund-sender/Xargo.toml
+++ b/programs/fund-sender/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/programs/fund-sender/src/lib.rs
+++ b/programs/fund-sender/src/lib.rs
@@ -1,0 +1,71 @@
+#![allow(clippy::result_large_err)]
+use crate::utils::errors::ErrorCode;
+use crate::utils::spend::*;
+use crate::utils::state::*;
+use anchor_lang::prelude::*;
+mod utils;
+
+// how to write it to leave it to be filled with new id for each deployed program for each climate project?
+declare_id!("rodTth5pXjkUfQpqMp7tEFdN1sdv2JwqhXg8RH9YrWD");
+
+#[program]
+pub mod fund_sender {
+    use super::*;
+
+    pub fn register_state(
+        ctx: Context<RegisterState>,
+        sunrise_state: Pubkey,
+        state_in: GenericStateInput,
+    ) -> Result<()> {
+        // register state account on chain, only need to ever be done once
+        let state = &mut ctx.accounts.state;
+        state.sunrise_state = sunrise_state;
+        state.update_authority = state_in.update_authority;
+        state.destination_seed = state_in.destination_seed;
+        state.destination_account = state_in.destination_account;
+        state.spend_threshold = state_in.spend_threshold;
+        state.output_yield_account_bump = *ctx.bumps.get("output_yield_account").unwrap();
+        state.total_spent = 0;
+
+        Ok(())
+    }
+
+    pub fn update_state(ctx: Context<UpdateState>, state_in: GenericStateInput) -> Result<()> {
+        // update state account parameters
+        let state = &mut ctx.accounts.state;
+        state.update_authority = state_in.update_authority;
+        state.destination_account = state_in.destination_account;
+        state.spend_threshold = state_in.spend_threshold;
+
+        Ok(())
+    }
+
+    pub fn send_fund<'info>(ctx: Context<'_, '_, '_, 'info, SendFund<'info>>) -> Result<()> {
+        // send yield to output_yield_accounts with specified proportions
+        let state = &mut ctx.accounts.state;
+        let output_yield_account = &mut ctx.accounts.output_yield_account;
+        let destination_account = &mut ctx.accounts.destination_account;
+        if destination_account.key() != state.destination_account {
+            return Err(ErrorCode::IncorrectDestinationAccount.into());
+        }
+
+        let amount: u64 = output_yield_account.lamports();
+        if amount >= state.spend_threshold {
+            transfer_native_cpi(
+                &state.key(),
+                &output_yield_account.to_account_info(),
+                // state.destination_account.to_account_info(), <- this leads to error trait bounds not satisfied, why?
+                &destination_account.to_account_info(),
+                amount,
+                state.output_yield_account_bump,
+                &state.destination_seed,
+                &ctx.accounts.system_program,
+            )?;
+            state.total_spent += amount;
+        } else {
+            return Err(ErrorCode::InsufficientFundsForTransaction.into());
+        }
+
+        Ok(())
+    }
+}

--- a/programs/fund-sender/src/utils/errors.rs
+++ b/programs/fund-sender/src/utils/errors.rs
@@ -1,0 +1,16 @@
+use anchor_lang::prelude::*;
+
+#[error_code]
+pub enum ErrorCode {
+    #[msg("Insufficient funds for transaction")]
+    InsufficientFundsForTransaction,
+
+    #[msg("Incorrect output yield account")]
+    IncorrectOutputYieldAccount,
+
+    #[msg("Incorrect destination account")]
+    IncorrectDestinationAccount,
+
+    #[msg("Incorrect update authority")]
+    Unauthorized,
+}

--- a/programs/fund-sender/src/utils/mod.rs
+++ b/programs/fund-sender/src/utils/mod.rs
@@ -1,0 +1,4 @@
+pub(crate) mod errors;
+pub(crate) mod seeds;
+pub(crate) mod spend;
+pub(crate) mod state;

--- a/programs/fund-sender/src/utils/seeds.rs
+++ b/programs/fund-sender/src/utils/seeds.rs
@@ -1,0 +1,2 @@
+pub const STATE: &[u8] = b"state";
+pub const OUTPUT_YIELD_ACCOUNT: &[u8] = b"output_yield_account";

--- a/programs/fund-sender/src/utils/spend.rs
+++ b/programs/fund-sender/src/utils/spend.rs
@@ -1,0 +1,33 @@
+use crate::utils::seeds::OUTPUT_YIELD_ACCOUNT;
+use anchor_lang::prelude::*;
+use anchor_lang::system_program;
+
+pub fn transfer_native_cpi<'a>(
+    state: &Pubkey,
+    source: &AccountInfo<'a>,
+    dest: &AccountInfo<'a>,
+    amount: u64,
+    source_bump: u8,
+    destination_seed: &[u8],
+    system_program: &Program<'a, System>,
+) -> Result<()> {
+    // transfer `amount` (in lamports) from `source` account to `dest` account
+    let state_bytes = state.to_bytes();
+    let bump_bytes = &[source_bump];
+    let seeds = &[
+        OUTPUT_YIELD_ACCOUNT,
+        destination_seed,
+        &state_bytes[..],
+        bump_bytes,
+    ][..];
+    let signer_seeds = &[seeds];
+    let cpi_ctx = CpiContext::new(
+        system_program.to_account_info(),
+        system_program::Transfer {
+            from: source.clone(),
+            to: dest.clone(),
+        },
+    )
+    .with_signer(signer_seeds);
+    system_program::transfer(cpi_ctx, amount)
+}

--- a/programs/fund-sender/src/utils/state.rs
+++ b/programs/fund-sender/src/utils/state.rs
@@ -1,0 +1,91 @@
+use crate::utils::errors::ErrorCode;
+use crate::utils::seeds::{OUTPUT_YIELD_ACCOUNT, STATE};
+use anchor_lang::prelude::*;
+
+/* This struct will be used for both registering and updating the state account */
+#[derive(AnchorSerialize, AnchorDeserialize, Clone)]
+pub struct GenericStateInput {
+    // seed phrase specifying which climate product to send funds to
+    pub destination_seed: Vec<u8>,
+    // an account that can update the `destination_account` and `spend_threshold`
+    pub update_authority: Pubkey,
+    // the account of the climate token
+    pub destination_account: Pubkey,
+    // minimum threshold of yield in output_yield_account before it is allowed to send funds (in lamports)
+    pub spend_threshold: u64,
+}
+
+#[account]
+pub struct State {
+    // the state account holding all the configs from GenericStateInput and the info of total funds spent on the destination
+    pub sunrise_state: Pubkey,
+    pub update_authority: Pubkey,
+    pub destination_seed: Vec<u8>,
+    pub destination_account: Pubkey,
+    pub spend_threshold: u64,
+    pub total_spent: u64,
+    pub output_yield_account_bump: u8,
+}
+
+impl State {
+    pub fn space(len_destination_seed: u8) -> usize {
+        // find space needed for state account for current config
+        32 + 32 + 4 + (len_destination_seed as usize) + 32 + 8 + 8 + 1 + 8 /* Discriminator */
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(sunrise_state: Pubkey, state_in: GenericStateInput)]
+pub struct RegisterState<'info> {
+    // to be used for registering state account on chain, only need to ever be done once
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(
+    init,
+    space = State::space(state_in.destination_seed.len() as u8),
+    seeds = [STATE, &state_in.destination_seed, sunrise_state.key().as_ref()],
+    payer = payer,
+    bump,
+    )]
+    pub state: Account<'info, State>,
+    #[account(
+    seeds = [OUTPUT_YIELD_ACCOUNT, &state_in.destination_seed, state.key().as_ref()],
+    bump,
+    )]
+    /// CHECK: Must be correctly derived from the state
+    pub output_yield_account: UncheckedAccount<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+#[instruction(state_in: GenericStateInput)]
+pub struct UpdateState<'info> {
+    // to be used for updating parameters of state account
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(
+    mut,
+    constraint = state.update_authority == payer.key() @ ErrorCode::Unauthorized,
+    )]
+    pub state: Account<'info, State>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+#[instruction(amount: u64)]
+pub struct SendFund<'info> {
+    // to allocate correct yield proportion to various output_yield_accounts
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub state: Account<'info, State>,
+    #[account(
+        mut,
+        seeds = [OUTPUT_YIELD_ACCOUNT, &state.destination_seed, state.key().as_ref()],
+        bump = state.output_yield_account_bump,
+    )]
+    /// CHECK: Must be correctly derived from the state
+    pub output_yield_account: UncheckedAccount<'info>,
+    /// CHECK: Must be correctly derived from the state
+    pub destination_account: UncheckedAccount<'info>,
+    pub system_program: Program<'info, System>,
+}


### PR DESCRIPTION
Each `fund-sender` program owns an output yield account PDA, and allow funds to be sent to an association destination (e.g. the ecoToken address) when the funds in the output yield account reach a specified threshold.